### PR TITLE
Load the configuration file and merge into params array

### DIFF
--- a/system/application/libraries/Postmark.php
+++ b/system/application/libraries/Postmark.php
@@ -51,6 +51,9 @@ class Postmark {
     function Postmark($params = array())
     {
         $this->CI =& get_instance();
+        $this->CI->config->load('postmark', TRUE);
+		
+        $params = array_merge($this->CI->config->config['postmark'], $params);
         
         if (count($params) > 0)
         {


### PR DESCRIPTION
As it is, the library doesn't pull in a postmark.php config file, meaning that you can't abstract your default configuration to a config file. This just loads the config file and merges arrays (defaults can be overwritten using $params array).
