### PR TITLE
Sanitises the name somewhat

### DIFF
--- a/system/application/libraries/Postmark.php
+++ b/system/application/libraries/Postmark.php
@@ -152,7 +152,10 @@ class Postmark {
      */
     function from($address, $name = null)
     {
-
+        
+        // Sanitise the name somewhat
+        $name = str_replace(',', '', $name);
+        
         if ( ! $this->validation == TRUE)
         {
             $this->from_address = $address;


### PR DESCRIPTION
We had issues with sending email to or from addresses with a name being passed that included a comma, this fixes that. Unlikely but sometimes people add qualifications after their name and delimit them with a comma.

i.e. "Bernadette Ennis BA (Hons), PG Dip DMS"