### PR TITLE
Adjust Postmark email validation

### DIFF
--- a/system/application/libraries/Postmark.php
+++ b/system/application/libraries/Postmark.php
@@ -546,23 +546,11 @@ class Postmark {
     function _validate_email($address)
     {
 
-        /*
-
-        http://en.wikipedia.org/wiki/Email_address#Syntax
-
-        The local-part of the email address may use any of these ASCII characters:
-
-        * Uppercase and lowercase English letters (a–z, A–Z)
-        * Digits 0 to 9
-        * Characters ! # $ % & ' * + - / = ? ^ _ ` { | } ~
-        * Character . (dot, period, full stop) provided that it is not the first or last character, and provided also that it does not appear two or more times consecutively (e.g. John..Doe@example.com).
-
-        */
-
+        // Trust in PHP FILTER_VALIDATE_EMAIL here
         $addresses = explode(',', $address);
 
         foreach($addresses as $k => $v) {
-            if ( ! preg_match("/^([a-z0-9\+_\-']+)(\.[a-z0-9\+_\-']+)*@([a-z0-9\-]+\.)+[a-z]{2,6}$/ix", trim($v))) {
+            if( is_string($v) || filter_var($v, FILTER_VALIDATE_EMAIL) ) {
                 return FALSE;
             }
         }


### PR DESCRIPTION
Email validation wasn't working for new style 'long' domain extensions such as '.education', this fixes that. Hat tip to @dmlogic.